### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,3 @@ jobs:
       run: | 
             cd SiteStatique
             mvn -B package --file pom.xml
-    - name: Test with Maven
-      run: | 
-            cd SiteStatique
-            mvn test


### PR DESCRIPTION
Le mvn test était redondant, car il était déjà effectué dans le package par défaut